### PR TITLE
Fix violation of the Interface Segregation Principle

### DIFF
--- a/src/Reactant/Models/Reactant.php
+++ b/src/Reactant/Models/Reactant.php
@@ -18,8 +18,10 @@ use I\Love\Reactant\ReactionCounter\Models\ReactionCounter;
 use I\Love\Reactant\ReactionTotal\Models\ReactionTotal;
 use I\Love\Reacter\Models\Reacter;
 use I\Love\ReactionType\Models\ReactionType;
+use I\Love\Support\Object\Nullable;
 
-interface Reactant
+interface Reactant extends
+    Nullable
 {
     public function getId(): string;
 
@@ -46,10 +48,6 @@ interface Reactant
     public function isEqualTo(self $that): bool;
 
     public function isNotEqualTo(self $that): bool;
-
-    public function isNull(): bool;
-
-    public function isNotNull(): bool;
 
     public function createReactionCounterOfType(ReactionType $type): void;
 

--- a/src/Reactant/ReactionCounter/Models/ReactionCounter.php
+++ b/src/Reactant/ReactionCounter/Models/ReactionCounter.php
@@ -15,8 +15,12 @@ namespace I\Love\Reactant\ReactionCounter\Models;
 
 use I\Love\Reactant\Models\Reactant;
 use I\Love\ReactionType\Models\ReactionType;
+use I\Love\Support\Object\Countable;
+use I\Love\Support\Object\Weightable;
 
-interface ReactionCounter
+interface ReactionCounter extends
+    Countable,
+    Weightable
 {
     public function getReactant(): Reactant;
 
@@ -25,16 +29,4 @@ interface ReactionCounter
     public function isReactionOfType(ReactionType $type): bool;
 
     public function isNotReactionOfType(ReactionType $type): bool;
-
-    public function getCount(): int;
-
-    public function getWeight(): float;
-
-    public function incrementCount(int $amount): void;
-
-    public function decrementCount(int $amount): void;
-
-    public function incrementWeight(float $amount): void;
-
-    public function decrementWeight(float $amount): void;
 }

--- a/src/Reactant/ReactionTotal/Models/ReactionTotal.php
+++ b/src/Reactant/ReactionTotal/Models/ReactionTotal.php
@@ -14,20 +14,12 @@ declare(strict_types=1);
 namespace I\Love\Reactant\ReactionTotal\Models;
 
 use I\Love\Reactant\Models\Reactant;
+use I\Love\Support\Object\Countable;
+use I\Love\Support\Object\Weightable;
 
-interface ReactionTotal
+interface ReactionTotal extends
+    Countable,
+    Weightable
 {
     public function getReactant(): Reactant;
-
-    public function getCount(): int;
-
-    public function getWeight(): float;
-
-    public function incrementCount(int $amount): void;
-
-    public function decrementCount(int $amount): void;
-
-    public function incrementWeight(float $amount): void;
-
-    public function decrementWeight(float $amount): void;
 }

--- a/src/Reacter/Models/Reacter.php
+++ b/src/Reacter/Models/Reacter.php
@@ -16,8 +16,10 @@ namespace I\Love\Reacter\Models;
 use I\Love\Reactant\Models\Reactant;
 use I\Love\Reacterable\Models\Reacterable;
 use I\Love\ReactionType\Models\ReactionType;
+use I\Love\Support\Object\Nullable;
 
-interface Reacter
+interface Reacter extends
+    Nullable
 {
     public function getId(): string;
 
@@ -39,8 +41,4 @@ interface Reacter
     public function isEqualTo(self $that): bool;
 
     public function isNotEqualTo(self $that): bool;
-
-    public function isNull(): bool;
-
-    public function isNotNull(): bool;
 }

--- a/src/Support/Object/Countable.php
+++ b/src/Support/Object/Countable.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of PHP I: Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace I\Love\Support\Object;
+
+interface Countable
+{
+    public function getCount(): int;
+
+    public function incrementCount(int $amount): void;
+
+    public function decrementCount(int $amount): void;
+}

--- a/src/Support/Object/Nullable.php
+++ b/src/Support/Object/Nullable.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of PHP I: Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace I\Love\Support\Object;
+
+interface Nullable
+{
+    public function isNull(): bool;
+
+    public function isNotNull(): bool;
+}

--- a/src/Support/Object/Weightable.php
+++ b/src/Support/Object/Weightable.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of PHP I: Love.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace I\Love\Support\Object;
+
+interface Weightable
+{
+    public function getWeight(): float;
+
+    public function incrementWeight(float $amount): void;
+
+    public function decrementWeight(float $amount): void;
+}


### PR DESCRIPTION
To avoid violation of Interface Segregation Principles we may extract following interfaces:
- Nullable
- Countable
- Weightable

There are many ways to design package namespace.

1. Keep these interfaces inside of the `I\Love` namespace
2. Bundle interfaces in helper package like `I\Support`, `I\Entity`, etc.
3. Create separate package for each of them:
- `I\Nullable`
- `I\Countable`
- `I\Weightable`
4. Mix two previous points and create bundle package with split sub-packages:
- `I\Object\Nullable`
- `I\Object\Countable`
- `I\Object\Weightable`